### PR TITLE
8.x eval fx

### DIFF
--- a/dgi_members.module
+++ b/dgi_members.module
@@ -45,6 +45,21 @@ function dgi_members_views_pre_render(ViewExecutable $view) {
 }
 
 /**
+ * Implements hook_form_form_id_alter().
+ */
+function dgi_members_form_block_form_alter(&$form, $form_state, $form_id) {
+  // In following with how Islandora core is handling block visibility,
+  // implementing this hook to unset our custom condition. There's too many to
+  // use well within the core block placement UI, and no other reasonable way to
+  // filter them out. See https://www.drupal.org/node/2284687. Use
+  // /admin/structure/context instead if you want to use these conditions
+  // to alter block layout.
+  // This hook is also doing the same thing in Islandora core, to hide the
+  // conditions it provides.
+  unset($form['visibility']['node_compound_current_has_term']);
+}
+
+/**
  * Implements hook_entity_view_mode_alter().
  */
 function dgi_members_entity_view_mode_alter(&$view_mode, EntityInterface $entity) {


### PR DESCRIPTION
Implementing hook_form_block_form_alter() as is found in islandora core:
https://git.drupalcode.org/project/islandora/-/blob/master/islandora.module#L338
Since this condition is not intended to be used on a block level, and islandora core set this precedent, implementing this hook to prevent unwanted evaluation of unrelated blocks.
Also an open issue on drupal.org regarding this level of configuration being added to core:
https://www.drupal.org/node/2284687