### PR TITLE
[DDST-939] allow configuration of default metadata display

### DIFF
--- a/config/install/dgi_members.settings.yml
+++ b/config/install/dgi_members.settings.yml
@@ -3,3 +3,4 @@ allow_compound_display_for_non_compound: FALSE
 display_non_compound_compound_as_first_member_of_itself: FALSE
 member_parameters:
   - active_member
+display_compound_object_metadata_by_default: FALSE

--- a/config/schema/dgi_members.schema.yml
+++ b/config/schema/dgi_members.schema.yml
@@ -17,4 +17,4 @@ dgi_members.settings:
         label: "A URL query parameter of interest."
     display_compound_object_metadata_by_default:
       type: boolean
-      label: 'Default to displaying the metadata of the compound object rather than the metadata of the active member being viewed."
+      label: 'Default to displaying the metadata of the compound object rather than the metadata of the active member being viewed.'

--- a/config/schema/dgi_members.schema.yml
+++ b/config/schema/dgi_members.schema.yml
@@ -15,3 +15,6 @@ dgi_members.settings:
       sequence:
         type: string
         label: "A URL query parameter of interest."
+    display_compound_object_metadata_by_default:
+      type: boolean
+      label: 'Default to displaying the metadata of the compound object rather than the metadata of the active member being viewed."

--- a/dgi_members.module
+++ b/dgi_members.module
@@ -79,6 +79,7 @@ function dgi_members_views_pre_render(ViewExecutable $view) {
   if (isset($view) && ($view->id() == 'compound_navigation')) {
     $members = dgi_members_get_members();
     $active = dgi_members_get_active();
+    $config = \Drupal::config('dgi_members.settings');
 
     if ($active) {
       $active_node_id = $active->id();
@@ -87,6 +88,8 @@ function dgi_members_views_pre_render(ViewExecutable $view) {
         = (empty($members) || !$members) ? FALSE : TRUE;
       $view->element['#attached']['drupalSettings']['dgi_members']['active_nid']
         = $active_node_id;
+      $view->element['#attached']['drupalSettings']['dgi_members']['display_compound_object_metadata']
+        = $config->get('display_compound_object_metadata_by_default') ?? FALSE;
     }
   }
 }

--- a/dgi_members.post_update.php
+++ b/dgi_members.post_update.php
@@ -15,3 +15,14 @@ function dgi_members_post_update_add_params(&$sandbox) {
   ]);
   $config->save(TRUE);
 }
+
+/**
+ * Implements hook_post_update_NAME().
+ */
+function dgi_members_post_update_add_metadata_display_flag(&$sandbox) {
+  $config = \Drupal::configFactory()->getEditable('dgi_members.settings');
+  // If this config has not been set, default to false.
+  $display_compound_object_metadata = $config->get('display_compound_object_metadata_by_default') ?? FALSE;
+  $config->set('display_compound_object_metadata_by_default', $display_compound_object_metadata);
+  $config->save(TRUE);
+}

--- a/js/compound_parts.js
+++ b/js/compound_parts.js
@@ -99,9 +99,16 @@
       const ac = 'element-active';
 
       if (drupalSettings.dgi_members.has_members) {
-        $(".compound-object-metadata").addClass('hidden');
-        $ec.removeClass(ac);
-        $pm.addClass(ac);
+        if (drupalSettings.dgi_members.display_compound_object_metadata) {
+          $(".compound-member-metadata").addClass('hidden');
+          $pm.removeClass(ac);
+          $ec.addClass(ac);
+        }
+        else {
+          $(".compound-object-metadata").addClass('hidden');
+          $ec.removeClass(ac);
+          $pm.addClass(ac);
+        }
       }
       else {
         $ec.addClass(ac);


### PR DESCRIPTION
When viewing a compound object, prior to these changes it would default to displaying the metadata for the currently viewed 'Part', and this allows us to switch that to display the 'Compound' metadata since that seems to be a desirable default display for some clients.

This isn't adding a config form to set this through the UI, but that can be added if desired later.