### PR TITLE
[SUP-6902] Iron out some wrinkles in non-compound compound navigation

### DIFF
--- a/dgi_members.module
+++ b/dgi_members.module
@@ -54,7 +54,7 @@ function dgi_members_views_pre_render(ViewExecutable $view) : void {
     $k = 0;
     $temp = [];
     $entity_id = (int) $view->argument['field_member_of_target_id']->argument;
-    if (count($members) > count($view->result) && $members[0] == $entity_id) {
+    if (count($members) > count($view->result) && reset($members) == $entity_id) {
       foreach ($view->result as $value) {
         if ($k == 0) {
           $entity = \Drupal::entityTypeManager()

--- a/dgi_members.module
+++ b/dgi_members.module
@@ -54,7 +54,15 @@ function dgi_members_views_pre_render(ViewExecutable $view) : void {
     $k = 0;
     $temp = [];
     $entity_id = (int) $view->argument['field_member_of_target_id']->argument;
-    if (count($members) > count($view->result) && reset($members) == $entity_id) {
+    // If there are more members than view rows, check if our processing
+    // prepended the compound as a member of itself, and if so, persist that in
+    // the view result display.
+    if (
+      $members
+      && count($members) > $view->total_rows
+      && $view->getCurrentPage() == 0
+      && reset($members) == $entity_id
+    ) {
       foreach ($view->result as $value) {
         if ($k == 0) {
           $entity = \Drupal::entityTypeManager()

--- a/dgi_members.module
+++ b/dgi_members.module
@@ -174,10 +174,10 @@ function dgi_members_entity_is_member(EntityInterface $entity) : bool {
  *   FALSE if no node available, or the active Node.
  */
 function dgi_members_get_active() : NodeInterface|false {
-  $active_member = \Drupal::request()->query->get('active_member');
+  $active_member_param = reset(\Drupal::config('dgi_members.settings')->get('member_parameters'));
   /** @var \Drupal\dgi_members\DgiMembersEntityOperationsInterface $service */
   $service = \Drupal::service('dgi_members.entity_service');
-  return $service->retrieveActiveMember($active_member);
+  return $service->retrieveActiveMember($active_member_param);
 }
 
 /**

--- a/src/DgiMembersEntityOperations.php
+++ b/src/DgiMembersEntityOperations.php
@@ -166,6 +166,7 @@ class DgiMembersEntityOperations implements DgiMembersEntityOperationsInterface 
       return FALSE;
     }
 
+    // This array ends up with nids for keys and values.
     $to_return = $this->entityTypeManager
       ->getStorage('node')
       ->getQuery()
@@ -182,6 +183,9 @@ class DgiMembersEntityOperations implements DgiMembersEntityOperationsInterface 
     ) {
       // Allow current entity to present as the first member of itself.
       array_unshift($to_return, $entity->id());
+      // Keep the array keys and values as nids instead of letting the
+      // array_unshift keys persist.
+      $to_return = array_combine($to_return, $to_return);
     }
 
     return $to_return;


### PR DESCRIPTION
The hardening here should fix the errors that were popping when using ajax in the compound_navigation view processing for the pager: https://github.com/discoverygarden/dgi_members/pull/28/files#diff-2568940613d4d903759c2dd116aec33e6195b8a3126382bd41a51425d98b05a4R57-R65

And this cleanup should ensure the active member is getting accurately retrieved: https://github.com/discoverygarden/dgi_members/pull/28/files#diff-2568940613d4d903759c2dd116aec33e6195b8a3126382bd41a51425d98b05a4R176-R180

The non-compound compound stuff is still kind of convoluted...
When the compound_navigation view is using ajax, the display of the object as its first child in the compound_navigation block will disappear if you go to another page of that view, using the pager, and then back to the first page. The use of hook_views_pre_render that adds the object to that display isn't currently set up to handle when ajax processing is used, and it's probably too much of an edge case to dive into that right now.